### PR TITLE
Add competency coverage to assessments page

### DIFF
--- a/components/courses/CompetencyCoverage.vue
+++ b/components/courses/CompetencyCoverage.vue
@@ -1,0 +1,142 @@
+<template>
+  <div>
+    <v-row>
+      <v-col cols="12" sm="6">
+        <v-switch
+          v-model="showSelected"
+          :label="$t('assessment.show_selected')"
+        />
+      </v-col>
+      <v-col cols="12" sm="6">
+        <v-select
+          v-model="selectedFilter"
+          :items="filters"
+          :label="$t('assessment.filter_by_competency')"
+          clearable
+          chips
+          dense
+        ></v-select>
+      </v-col>
+    </v-row>
+    <v-data-table
+      v-model="selected"
+      hide-default-footer
+      dense
+      show-select
+      disable-sort
+      disable-pagination
+      item-class="itemStyle"
+      :items-per-page="-1"
+      :headers="headers"
+      :items="items"
+    >
+    </v-data-table>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CompetencyCoverage',
+  props: {
+    competencies: {
+      type: Array,
+      required: true,
+    },
+    assessments: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      selectedFilter: null,
+      selected: [],
+      showSelected: false,
+    }
+  },
+  computed: {
+    filters() {
+      const filters = []
+      for (const courseCompetency of this.competencies) {
+        filters.push(courseCompetency.competency.code)
+      }
+      return filters
+    },
+    headers() {
+      const headers = [
+        {
+          text: this.$tc('assessment._', 1),
+          align: 'start',
+          sortable: false,
+          value: 'name',
+        },
+      ]
+      for (const courseCompetency of this.competencies) {
+        headers.push({
+          text: courseCompetency.competency.code,
+          value: courseCompetency.competency.code,
+        })
+      }
+      return headers
+    },
+    items() {
+      // For each competency, get the stars earnable by this assignment
+      const items = []
+      // Collect ids of assessments that must be shown
+      const idToShow = []
+      for (const assessment of this.showSelected
+        ? this.selected
+        : this.assessments)
+        if (assessment.id !== 'total') idToShow.push(assessment.id)
+      // Initialize dict for stars sum
+      const totalStars = {
+        name: 'Total',
+        id: 'total',
+        isSelectable: false,
+        itemStyle: 'totalRow',
+      }
+      for (const courseCompetency of this.competencies) {
+        totalStars[courseCompetency.competency.code] = 0
+      }
+      for (const assessmentId of idToShow) {
+        const assessment = this.assessments.filter(
+          (x) => x.id === assessmentId
+        )[0]
+        const row = { name: assessment.code, id: assessment.id }
+        const assessmentComp = {}
+        // Collect star information for this assigment in a dict instead of a list
+        let passFilter = false
+        for (const comp of assessment.competencies) {
+          assessmentComp[comp.competency.code] = comp.stars
+          if (this.selectedFilter === comp.competency.code) passFilter = true
+        }
+        // Do not display this assignment if it doesn't contain filter competency
+        if (this.selectedFilter && !passFilter) continue
+
+        // Collect complete stars information for all competencies
+        for (const courseCompetency of this.competencies) {
+          if (assessmentComp[courseCompetency.competency.code]) {
+            row[courseCompetency.competency.code] =
+              assessmentComp[courseCompetency.competency.code]
+            // Update total
+            totalStars[courseCompetency.competency.code] +=
+              assessmentComp[courseCompetency.competency.code]
+          } else row[courseCompetency.competency.code] = ''
+        }
+        items.push(row)
+      }
+      items.push(totalStars)
+      return items
+    },
+  },
+}
+</script>
+<style>
+.totalRow {
+  font-weight: bold;
+  background-color: lightgray;
+}
+.totalRow .v-simple-checkbox {
+  display: none;
+}
+</style>

--- a/gql/manage/getCourseAssessments.gql
+++ b/gql/manage/getCourseAssessments.gql
@@ -1,11 +1,24 @@
 query GetCourseAssessments($code: ID!) {
   course(code: $code) {
     assessments {
-      code
       id
       name
+      code
+      competencies {
+        competency {
+          code
+        }
+        stars
+      }
     }
     code
     name
+    competencies {
+      competency {
+        code
+        name
+      }
+      category
+    }
   }
 }

--- a/lang/en-GB.json
+++ b/lang/en-GB.json
@@ -24,15 +24,17 @@
       "date": "Deadline : {deadline}"
     },
     "description": "@:global.description._",
+    "filter_by_competency": "Filter by competency",
     "name": "@:global.name",
-    "nb_of": "Number of assessments",
     "nb": "{nb} evaluation | {nb} evaluations",
+    "nb_of": "Number of assessments",
     "no": "There are no assessment for now",
     "schedule": {
       "_": "Schedule",
-      "start": "Start date",
-      "end": "End date"
+      "end": "End date",
+      "start": "Start date"
     },
+    "show_selected": "Show only selected rows",
     "start": {
       "_": "Opening",
       "date": "Opens on : {start}"
@@ -46,23 +48,23 @@
   "competency": {
     "_": "Competency | Competencies",
     "category": {
-      "no": "No category",
+      "advanced": "Advanced",
       "basic": "Basic",
-      "advanced": "Advanced"
+      "no": "No category"
     },
     "code": "@:global.code",
     "coordinator": "@:global.coordinator",
     "create": "@:general.create a competency",
     "creator": {
+      "external": "External",
       "own": "Myself",
-      "partners": "Affiliations",
-      "external": "External"
+      "partners": "Affiliations"
     },
     "description": "@:global.description._",
     "filter": {
-      "visibility": "@:global.visibility._",
       "creator": "@:general.creator",
-      "tags": "Tags"
+      "tags": "Tags",
+      "visibility": "@:global.visibility._"
     },
     "learning_outcomes": {
       "_": "Learning outcomes"
@@ -74,8 +76,8 @@
     "partners": "@:global.partners",
     "public": "@:global.visibility.public",
     "show_by": {
-      "level": "Show by level",
-      "category": "Show by category"
+      "category": "Show by category",
+      "level": "Show by level"
     },
     "tags": "@:global.tag",
     "type": {
@@ -100,6 +102,7 @@
       "category": "Category",
       "subcategory": "Subcategory"
     },
+    "competency_coverage": "Competency coverage",
     "coordinator": "@:global.coordinator",
     "create": "@:general.create a course",
     "description": "@:global.description._",
@@ -137,11 +140,11 @@
     "request_invite": "Request an invite",
     "schedule": {
       "_": "Schedule",
-      "start": "Start date",
       "end": "End date",
-      "registrationsStart": "Start of registrations",
+      "evaluationsEnd": "End of evaluations",
       "registrationsEnd": "End of registrations",
-      "evaluationsEnd": "End of evaluations"
+      "registrationsStart": "Start of registrations",
+      "start": "Start date"
     },
     "span": {
       "_": "Span",
@@ -178,15 +181,15 @@
     "BANNER_UPDATE_ERROR": "An unexpected error occurred while updating the banner.",
     "DUPLICATE_COMPETENCIES": "The same competency cannot be used more than once",
     "DUPLICATE_COURSES": "The same course cannot be used more than once",
-    "EXISTING_EMAIL_ADDRESS": "Impossible to create an account with this email address",
     "EXISTING_CODE": "The specified code already exists",
+    "EXISTING_EMAIL_ADDRESS": "Impossible to create an account with this email address",
     "INVALID_CREDENTIALS": "Invalid credentials",
     "INVALID_EMAIL_ADDRESS": "Invalid email address",
     "INVALID_PASSWORD": "Password not strong enough",
     "INVITE_REQUEST_FAILED": "Invite request failed",
     "MISSING_BASIC_COMPETENCY": "There must be at least one basic competency",
-    "MISSING_MANDATORY_COURSE": "There must be at least one mandatory course",
     "MISSING_FIELDS": "Some mandatory fields are missing",
+    "MISSING_MANDATORY_COURSE": "There must be at least one mandatory course",
     "REGISTRATION_FAILED": "Registration failed"
   },
   "general": {
@@ -218,8 +221,8 @@
       "_": "Banner",
       "edit": "Edit the banner"
     },
-    "coordinator": "Coordinator",
     "code": "Code",
+    "coordinator": "Coordinator",
     "date": "Date",
     "description": {
       "_": "Description",
@@ -259,16 +262,16 @@
     }
   },
   "homepage": {
-    "welcome": "Welcome!",
     "presentation": "<p>The <em>TLC Academy</em> is the best place where you can <b>learn anything</b> and gain competencies!</p><p>Whether for medium or long term trainings, or for a simple micro-course, learn at your <b>own pace</b> and accumulate <b>competency stars</b> to strenghten your personal profile.</p>",
     "see_all_courses": "See all courses",
+    "see_all_partners": "See all partners",
     "see_all_programs": "See all programs",
-    "see_all_partners": "See all partners"
+    "welcome": "Welcome!"
   },
   "partner": {
     "_": "Partner | Partners",
-    "no": "There are no partners available for now.",
     "abbreviation": "Abbreviation",
+    "no": "There are no partners available for now.",
     "website": "Website"
   },
   "program": {
@@ -313,8 +316,8 @@
   "registration": {
     "_": "Registration | Registrations",
     "date": "Registration date",
-    "invite_request_sent": "Invite request sent",
     "invite_received": "Invite received",
+    "invite_request_sent": "Invite request sent",
     "nb_of": "Number of registrations",
     "registered_on": "Registered on {date}",
     "status": "Registration @.lower:general.status"
@@ -328,10 +331,10 @@
     "COMPETENCY_CREATED": "Competency successfully created!",
     "COURSE_CREATED": "Course successfully created!",
     "PROGRAM_CREATED": "Program successfully created!",
-    "SIGN_IN_SUCCESSFUL": "Successfully signed in!",
-    "SIGN_UP_SUCCESSFUL": "Successfully signed up!",
     "REGISTERED": "Successfully registered!",
-    "REQUEST_INVITE_SENT": "Invite request successfully sent!"
+    "REQUEST_INVITE_SENT": "Invite request successfully sent!",
+    "SIGN_IN_SUCCESSFUL": "Successfully signed in!",
+    "SIGN_UP_SUCCESSFUL": "Successfully signed up!"
   },
   "user": {
     "_": "User | Users",

--- a/lang/fr-BE.json
+++ b/lang/fr-BE.json
@@ -24,15 +24,17 @@
       "date": "Echéance : {deadline}"
     },
     "description": "@:global.description._",
+    "filter_by_competency": "Filtrer par compétence",
     "name": "@:global.name",
-    "nb_of": "Nombre d'évaluations",
     "nb": "{nb} évaluation | {nb} évaluations",
+    "nb_of": "Nombre d'évaluations",
     "no": "Il n'y a aucune évaluation pour le moment",
     "schedule": {
       "_": "Calendrier",
-      "start": "Date de début",
-      "end": "Date de fin"
+      "end": "Date de fin",
+      "start": "Date de début"
     },
+    "show_selected": "Filtrer sur la sélection",
     "start": {
       "_": "Date d'ouverture",
       "date": "Ouverture : {start}"
@@ -46,23 +48,23 @@
   "competency": {
     "_": "Compétence | Compétences",
     "category": {
-      "no": "Pas de catégorie",
+      "advanced": "Avancée",
       "basic": "Basique",
-      "advanced": "Avancée"
+      "no": "Pas de catégorie"
     },
     "code": "@:global.code",
     "coordinator": "@:global.coordinator",
     "create": "@:general.create une compétence",
     "creator": {
+      "external": "Externe",
       "own": "Moi-même",
-      "partners": "Affiliations",
-      "external": "Externe"
+      "partners": "Affiliations"
     },
     "description": "@:global.description._",
     "filter": {
-      "visibility": "@:global.visibility._",
       "creator": "@:general.creator",
-      "tags": "Tags"
+      "tags": "Tags",
+      "visibility": "@:global.visibility._"
     },
     "learning_outcomes": {
       "_": "Acquis d'apprentissage"
@@ -74,8 +76,8 @@
     "partners": "@:global.partners",
     "public": "@:global.visibility.public",
     "show_by": {
-      "level": "Montrer par niveau",
-      "category": "Montrer par catégorie"
+      "category": "Montrer par catégorie",
+      "level": "Montrer par niveau"
     },
     "tags": "@:global.tag",
     "type": {
@@ -92,14 +94,15 @@
   "course": {
     "_": "Cours",
     "assessments_list": "Liste des évaluations du cours",
-    "colophon": "Colophon",
     "code": "@:global.code",
+    "colophon": "Colophon",
     "competencies": {
       "_": "Compétences",
       "add": "Ajouter une compétence",
       "category": "Catégorie",
       "subcategory": "Sous-catégorie"
     },
+    "competency_coverage": "Couverture des compétences",
     "coordinator": "@:global.coordinator",
     "create": "@:general.create un cours",
     "description": "@:global.description._",
@@ -137,11 +140,11 @@
     "request_invite": "Demander une invitation",
     "schedule": {
       "_": "Calendrier",
-      "start": "Date de début",
       "end": "Date de fin",
-      "registrationsStart": "Début des inscriptions",
+      "evaluationsEnd": "Fin des évaluations",
       "registrationsEnd": "Fin des inscriptions",
-      "evaluationsEnd": "Fin des évaluations"
+      "registrationsStart": "Début des inscriptions",
+      "start": "Date de début"
     },
     "span": {
       "_": "Durée",
@@ -178,15 +181,15 @@
     "BANNER_UPDATE_ERROR": "Une erreur inattendue s'est produite lors de la mise à jour de la bannière.",
     "DUPLICATE_COMPETENCIES": "La même compétence ne peut pas être utilisée plus d'une fois",
     "DUPLICATE_COURSES": "Le même cours ne peut pas être utilisé plus d'une fois",
-    "EXISTING_EMAIL_ADDRESS": "Impossible de créer un compte avec cette adresse e-mail",
     "EXISTING_CODE": "Le code spécifié existe déjà",
+    "EXISTING_EMAIL_ADDRESS": "Impossible de créer un compte avec cette adresse e-mail",
     "INVALID_CREDENTIALS": "Mauvais identifiants",
     "INVALID_EMAIL_ADDRESS": "Mauvaise adresse e-mail",
     "INVALID_PASSWORD": "Mot de passe pas assez fort",
     "INVITE_REQUEST_FAILED": "Demande d'invitation échouée",
     "MISSING_BASIC_COMPETENCY": "Il doit y avoir au moins une compétence basique",
-    "MISSING_MANDATORY_COURSE": "Il doit y avoir au moins un cours obligatoire",
     "MISSING_FIELDS": "Certains champs obligatoires sont manquants",
+    "MISSING_MANDATORY_COURSE": "Il doit y avoir au moins un cours obligatoire",
     "REGISTRATION_FAILED": "Inscription échouée"
   },
   "general": {
@@ -259,16 +262,16 @@
     }
   },
   "homepage": {
-    "welcome": "Bienvenue !",
     "presentation": "<p>La <em>TLC Academy</em> est le meilleur endroit où vous pouvez <b>tout apprendre</b> et acquérir des compétences !</p><p>Que ce soit pour des formations à moyen ou long terme, ou pour un simple micro-cours, apprenez à votre <b>propre rythme</b> et accumulez des <b>étoiles de compétence</b> pour renforcer votre profil personnel.</p>",
     "see_all_courses": "Voir tous les cours",
+    "see_all_partners": "Voir tous les partenaires",
     "see_all_programs": "Voir tous les programmes",
-    "see_all_partners": "Voir tous les partenaires"
+    "welcome": "Bienvenue !"
   },
   "partner": {
     "_": "Partenaire | Partenaires",
-    "no": "Il n'y a pas de partenaires disponibles pour le moment.",
     "abbreviation": "Abréviation",
+    "no": "Il n'y a pas de partenaires disponibles pour le moment.",
     "website": "Site web"
   },
   "program": {
@@ -313,8 +316,8 @@
   "registration": {
     "_": "Inscription | Inscriptions",
     "date": "Date d'inscription",
-    "invite_request_sent": "Demande d'invitation envoyée",
     "invite_received": "Invitation reçue",
+    "invite_request_sent": "Demande d'invitation envoyée",
     "nb_of": "Nombre d'inscriptions",
     "registered_on": "Inscrit(e) le {date}",
     "status": "@:general.status de l'inscription"
@@ -328,10 +331,10 @@
     "COMPETENCY_CREATED": "Compétence créée avec succès !",
     "COURSE_CREATED": "Cours créé avec succès !",
     "PROGRAM_CREATED": "Programme créé avec succès !",
-    "SIGN_IN_SUCCESSFUL": "Connecté(e) avec succès !",
-    "SIGN_UP_SUCCESSFUL": "Inscrit(e) avec succès !",
     "REGISTERED": "Inscrit(e) avec succès !",
-    "REQUEST_INVITE_SENT": "Demande d'invitation envoyée avec succès !"
+    "REQUEST_INVITE_SENT": "Demande d'invitation envoyée avec succès !",
+    "SIGN_IN_SUCCESSFUL": "Connecté(e) avec succès !",
+    "SIGN_UP_SUCCESSFUL": "Inscrit(e) avec succès !"
   },
   "user": {
     "_": "Utilisateur | Utilisateurs",

--- a/pages/manage/courses/_code/assessments/_id.vue
+++ b/pages/manage/courses/_code/assessments/_id.vue
@@ -21,7 +21,7 @@
                   {{ $t('assessment.description') }}
                 </v-tab>
                 <v-tab>
-                  {{ $t('assessment.competencies') }}
+                  {{ $t('assessment.competencies._') }}
                 </v-tab>
               </v-tabs>
 

--- a/pages/manage/courses/_code/assessments/index.vue
+++ b/pages/manage/courses/_code/assessments/index.vue
@@ -1,50 +1,83 @@
 <template>
   <ApolloQuery
     :query="require('~/gql/manage/getCourseAssessments.gql')"
-    :update="(data) => data.course"
     :variables="{ code: $route.params.code }"
   >
-    <template #default="{ result: { error, data: course }, isLoading }">
+    <template #default="{ result: { error, data }, isLoading }">
       <div v-if="isLoading">{{ $t('global.loading') }}</div>
 
-      <div v-else-if="course">
-        <h2>{{ course.name }}</h2>
-
+      <div v-else-if="data.course">
+        <h2>
+          {{ data.course.name }} -
+          {{ $tc('assessment._', data.course.assessments.length) }}
+        </h2>
         <v-row>
           <v-col cols="12" md="9">
-            <v-card v-if="course.assessments && course.assessments.length">
-              <v-list class="pa-0">
-                <template v-for="(assessment, i) in course.assessments">
-                  <v-list-item
-                    :key="assessment.code"
-                    :to="{
-                      name: 'manage-courses-code-assessments-id',
-                      params: { code: course.code, id: assessment.id },
-                    }"
-                  >
-                    <v-list-item-content>
-                      <v-list-item-title>
-                        <b>{{ assessment.code }}</b>
-                        &nbsp;–&nbsp;{{ assessment.name }}
-                      </v-list-item-title>
-                      <v-list-item-subtitle>
-                        <!-- $t('assessment.category') : {{ assessment.category }} -->
-                      </v-list-item-subtitle>
-                    </v-list-item-content>
-                  </v-list-item>
-                  <v-divider
-                    v-if="i < course.assessments.length - 1"
-                    :key="i"
-                  />
-                </template>
-              </v-list>
+            <v-card>
+              <v-tabs v-model="currentTab" show-arrows>
+                <v-tab>
+                  {{ $tc('assessment._', data.course.assessments.length) }}
+                </v-tab>
+                <v-tab v-if="data.course.competencies?.length">
+                  {{ $t('course.competency_coverage') }}
+                </v-tab>
+              </v-tabs>
+              <v-card-text class="text--primary">
+                <v-tabs-items v-model="currentTab">
+                  <v-tab-item>
+                    <div
+                      v-if="
+                        data.course.assessments &&
+                        data.course.assessments.length
+                      "
+                    >
+                      <v-list class="pa-0">
+                        <template
+                          v-for="(assessment, i) in data.course.assessments"
+                        >
+                          <v-list-item
+                            :key="assessment.code"
+                            :to="{
+                              name: 'manage-courses-code-assessments-id',
+                              params: {
+                                code: data.course.code,
+                                id: assessment.id,
+                              },
+                            }"
+                          >
+                            <v-list-item-content>
+                              <v-list-item-title>
+                                <b>{{ assessment.code }}</b>
+                                &nbsp;–&nbsp;{{ assessment.name }}
+                              </v-list-item-title>
+                            </v-list-item-content>
+                          </v-list-item>
+                          <v-divider
+                            v-if="i < data.course.assessments.length - 1"
+                            :key="i"
+                          />
+                        </template>
+                      </v-list>
+                    </div>
+                    <div
+                      v-else-if="
+                        data.course.assessments &&
+                        !data.course.assessments.length
+                      "
+                    >
+                      {{ $t('assessment.no') }}
+                    </div>
+                  </v-tab-item>
+                  <v-tab-item>
+                    <competency-coverage
+                      :competencies="data.course.competencies"
+                      :assessments="data.course.assessments"
+                    />
+                  </v-tab-item>
+                </v-tabs-items>
+              </v-card-text>
             </v-card>
-
-            <div v-else-if="course.assessments && !course.assessments.length">
-              {{ $t('assessment.no') }}
-            </div>
-
-            <v-skeleton-loader v-else type="table" />
+            <!-- <v-skeleton-loader v-else type="table" /> -->
           </v-col>
 
           <v-col
@@ -53,9 +86,9 @@
             :order="$vuetify.breakpoint.smAndDown ? 'first' : undefined"
           >
             <assessments-list-info-panel
-              v-if="course.assessments"
-              :assessments="course.assessments"
-              :code="course.code"
+              v-if="data.course.assessments"
+              :assessments="data.course.assessments"
+              :code="data.course.code"
             />
           </v-col>
         </v-row>
@@ -67,8 +100,15 @@
 </template>
 
 <script>
+import CompetencyCoverage from '~/components/courses/CompetencyCoverage.vue'
 export default {
   name: 'ManageCourseAssessmentsPage',
+  components: { CompetencyCoverage },
+  data() {
+    return {
+      currentTab: '0',
+    }
+  },
   meta: {
     roles: ['teacher'],
   },

--- a/pages/manage/courses/_code/assessments/index.vue
+++ b/pages/manage/courses/_code/assessments/index.vue
@@ -18,7 +18,13 @@
                 <v-tab>
                   {{ $tc('assessment._', data.course.assessments.length) }}
                 </v-tab>
-                <v-tab v-if="data.course.competencies?.length">
+                <v-tab
+                  v-if="
+                    data.course.competencies?.length &&
+                    data.course.assessments &&
+                    data.course.assessments.length
+                  "
+                >
                   {{ $t('course.competency_coverage') }}
                 </v-tab>
               </v-tabs>
@@ -69,10 +75,17 @@
                     </div>
                   </v-tab-item>
                   <v-tab-item>
-                    <competency-coverage
-                      :competencies="data.course.competencies"
-                      :assessments="data.course.assessments"
-                    />
+                    <div
+                      v-if="
+                        data.course.assessments &&
+                        data.course.assessments.length
+                      "
+                    >
+                      <competency-coverage
+                        :competencies="data.course.competencies"
+                        :assessments="data.course.assessments"
+                      />
+                    </div>
                   </v-tab-item>
                 </v-tabs-items>
               </v-card-text>


### PR DESCRIPTION
This PR displays a competency coverage tab in a tab onto the assessments page of a course. 

**Implemented features** : 
- Ability to select rows to display
- Filter on competency

**Further work** : 
- Investigate the rendering with lots of competencies (>10)
- Add a filter for basic/advanced competencies
- Add a tooltip or an expand button on assessments  to get more info + tooltip on competency code to get competency full name
- ... 